### PR TITLE
fix(ios): old arch 'clusters' prop type of RCT_EXPORT_VIEW_PROP

### DIFF
--- a/ios/RNCNaverMapViewManager.mm
+++ b/ios/RNCNaverMapViewManager.mm
@@ -61,7 +61,7 @@ RCT_EXPORT_VIEW_PROPERTY(isTiltGesturesEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(isRotateGesturesEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(isStopGesturesEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(locale, NSString)
-RCT_EXPORT_VIEW_PROPERTY(clusters, NSArray)
+RCT_EXPORT_VIEW_PROPERTY(clusters, NSDictionary)
 RCT_EXPORT_VIEW_PROPERTY(fpsLimit, NSInteger)
 
 // event


### PR DESCRIPTION
<!-- Thank you for contributing package 🤗 -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhance (enhance performance, api, etc)
- [ ] Chore
- [ ] This change requires a documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## What does this change?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #44 🎯

