### PR TITLE
fix: iOS 아이콘 처음 렌더 시 기본마커 보이지 않도록 수정

### DIFF
--- a/OverlayImageManager.h
+++ b/OverlayImageManager.h
@@ -1,0 +1,11 @@
+
+#import <Foundation/Foundation.h>
+#import <NMapsMap/NMFOverlayImage.h>
+
+@interface OverlayImageManager : NSObject
+
+@property (nonatomic, strong, readonly) NMFOverlayImage *transparentOverlayImage;
+
++ (instancetype)sharedManager;
+
+@end

--- a/OverlayImageManager.mm
+++ b/OverlayImageManager.mm
@@ -1,0 +1,30 @@
+
+#import "OverlayImageManager.h"
+
+@implementation OverlayImageManager
+
++ (instancetype)sharedManager {
+  static OverlayImageManager *sharedManager = nil;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    sharedManager = [[OverlayImageManager alloc] init];
+  });
+  return sharedManager;
+}
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    CGSize size = CGSizeMake(1, 1); // 최소 크기 이미지
+    UIGraphicsBeginImageContextWithOptions(size, NO, 0.0);
+    [[UIColor clearColor] setFill]; // 투명 색상 설정
+    UIRectFill(CGRectMake(0, 0, size.width, size.height));
+    UIImage *transparentImage = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    
+    _transparentOverlayImage = [NMFOverlayImage overlayImageWithImage:transparentImage];
+  }
+  return self;
+}
+
+@end

--- a/ios/RNCNaverMapViewImpl.mm
+++ b/ios/RNCNaverMapViewImpl.mm
@@ -7,6 +7,7 @@
 
 #import "RNCNaverMapViewImpl.h"
 #import "RNCNaverMapView.h"
+#import "OverlayImageManager.h"
 
 @implementation RNCNaverMapViewImpl {
   BOOL _initialRegionSet;
@@ -70,6 +71,12 @@
   // This is where we intercept them and do the appropriate underlying mapview action.
   if ([subview isKindOfClass:[RNCNaverMapMarker class]]) {
     auto marker = static_cast<RNCNaverMapMarker*>(subview).inner;
+    
+    if(marker.iconImage == NMF_MARKER_IMAGE_GREEN){
+      NMFOverlayImage *transparentImage = [OverlayImageManager sharedManager].transparentOverlayImage;
+      marker.iconImage = transparentImage;
+    }
+    
     marker.mapView = self.mapView;
   } else if ([subview isKindOfClass:[RNCNaverMapCircle class]]) {
     auto marker = static_cast<RNCNaverMapCircle*>(subview).inner;


### PR DESCRIPTION
<!-- Thank you for contributing package 🤗 -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhance (enhance performance, api, etc)
- [ ] Chore
- [ ] This change requires a documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## What does this change?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

커스텀 마커를 많이 렌더시킬 때 마커 첫 렌더 시 기본 마커가 렌더됩니다.

이를 보이지 않게 하기위해 기본마커일때에는 투명 비트맵을 아이콘이미지에 넣도록합니다.

# NOTE
기본 마커만 사용하는 경우 마커가 아예 안보이게됨. 커스텀마커를 사용하거나 이 PR 에서 수정한 코드를 주석처리하고 사용할 것.

