### PR TITLE
fix: react native 0.78 & kotlin 2.0.21 android compile error

### DIFF
--- a/android/src/newarch/RNCNaverMapArrowheadPathManagerSpec.kt
+++ b/android/src/newarch/RNCNaverMapArrowheadPathManagerSpec.kt
@@ -8,7 +8,7 @@ import com.facebook.react.viewmanagers.RNCNaverMapArrowheadPathManagerInterface
 
 abstract class RNCNaverMapArrowheadPathManagerSpec<T : View> :
   SimpleViewManager<T>(),
-  RNCNaverMapArrowheadPathManagerInterface<T?> {
+  RNCNaverMapArrowheadPathManagerInterface<T> {
   private val mDelegate: ViewManagerDelegate<T>
 
   init {

--- a/android/src/newarch/RNCNaverMapCircleManagerSpec.kt
+++ b/android/src/newarch/RNCNaverMapCircleManagerSpec.kt
@@ -8,7 +8,7 @@ import com.facebook.react.viewmanagers.RNCNaverMapCircleManagerInterface
 
 abstract class RNCNaverMapCircleManagerSpec<T : View> :
   SimpleViewManager<T>(),
-  RNCNaverMapCircleManagerInterface<T?> {
+  RNCNaverMapCircleManagerInterface<T> {
   private val mDelegate: ViewManagerDelegate<T>
 
   init {

--- a/android/src/newarch/RNCNaverMapGroundManagerSpec.kt
+++ b/android/src/newarch/RNCNaverMapGroundManagerSpec.kt
@@ -8,7 +8,7 @@ import com.facebook.react.viewmanagers.RNCNaverMapGroundManagerInterface
 
 abstract class RNCNaverMapGroundManagerSpec<T : View> :
   SimpleViewManager<T>(),
-  RNCNaverMapGroundManagerInterface<T?> {
+  RNCNaverMapGroundManagerInterface<T> {
   private val mDelegate: ViewManagerDelegate<T>
 
   init {

--- a/android/src/newarch/RNCNaverMapPathManagerSpec.kt
+++ b/android/src/newarch/RNCNaverMapPathManagerSpec.kt
@@ -8,7 +8,7 @@ import com.facebook.react.viewmanagers.RNCNaverMapPathManagerInterface
 
 abstract class RNCNaverMapPathManagerSpec<T : View> :
   SimpleViewManager<T>(),
-  RNCNaverMapPathManagerInterface<T?> {
+  RNCNaverMapPathManagerInterface<T> {
   private val mDelegate: ViewManagerDelegate<T>
 
   init {

--- a/android/src/newarch/RNCNaverMapPolygonManagerSpec.kt
+++ b/android/src/newarch/RNCNaverMapPolygonManagerSpec.kt
@@ -8,7 +8,7 @@ import com.facebook.react.viewmanagers.RNCNaverMapPolygonManagerInterface
 
 abstract class RNCNaverMapPolygonManagerSpec<T : View> :
   SimpleViewManager<T>(),
-  RNCNaverMapPolygonManagerInterface<T?> {
+  RNCNaverMapPolygonManagerInterface<T> {
   private val mDelegate: ViewManagerDelegate<T>
 
   init {

--- a/android/src/newarch/RNCNaverMapPolylineManagerSpec.kt
+++ b/android/src/newarch/RNCNaverMapPolylineManagerSpec.kt
@@ -8,7 +8,7 @@ import com.facebook.react.viewmanagers.RNCNaverMapPolylineManagerInterface
 
 abstract class RNCNaverMapPolylineManagerSpec<T : View> :
   SimpleViewManager<T>(),
-  RNCNaverMapPolylineManagerInterface<T?> {
+  RNCNaverMapPolylineManagerInterface<T> {
   private val mDelegate: ViewManagerDelegate<T>
 
   init {


### PR DESCRIPTION
error message
e: file:..../node_modules/@mj-studio/react-native-naver-map/android/src/newarch/RNCNaverMapArrowheadPathManagerSpec.kt:15:57 Argument type mismatch: actual type is 'com.mjstudio.reactnativenavermap.RNCNaverMapArrowheadPathManagerSpec<T>', but 'U!' was expected.
e: file:..../node_modules/@mj-studio/react-native-naver-map/android/src/newarch/RNCNaverMapCircleManagerSpec.kt:15:50 Argument type mismatch: actual type is 'com.mjstudio.reactnativenavermap.RNCNaverMapCircleManagerSpec<T>', but 'U!' was expected.
e: file:..../node_modules/@mj-studio/react-native-naver-map/android/src/newarch/RNCNaverMapGroundManagerSpec.kt:15:50 Argument type mismatch: actual type is 'com.mjstudio.reactnativenavermap.RNCNaverMapGroundManagerSpec<T>', but 'U!' was expected.
e: file:..../node_modules/@mj-studio/react-native-naver-map/android/src/newarch/RNCNaverMapPathManagerSpec.kt:15:48 Argument type mismatch: actual type is 'com.mjstudio.reactnativenavermap.RNCNaverMapPathManagerSpec<T>', but 'U!' was expected.
e: file:..../node_modules/@mj-studio/react-native-naver-map/android/src/newarch/RNCNaverMapPolygonManagerSpec.kt:15:51 Argument type mismatch: actual type is 'com.mjstudio.reactnativenavermap.RNCNaverMapPolygonManagerSpec<T>', but 'U!' was expected.
e: file:..../node_modules/@mj-studio/react-native-naver-map/android/src/newarch/RNCNaverMapPolylineManagerSpec.kt:15:52 Argument type mismatch: actual type is 'com.mjstudio.reactnativenavermap.RNCNaverMapPolylineManagerSpec<T>', but 'U!' was expected.


--- android/build.gradle
```
buildscript {
    ext {
        buildToolsVersion = "35.0.0"
        minSdkVersion = 24
        compileSdkVersion = 35
        targetSdkVersion = 35
        ndkVersion = "27.1.12297006"
        kotlinVersion = "2.0.21"
    }
    repositories {
        google()
        mavenCentral()
    }
    dependencies {
        classpath("com.android.tools.build:gradle")
        classpath("com.facebook.react:react-native-gradle-plugin")
        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
    }
}

allprojects {
    repositories {
        maven {
            url "https://repository.map.naver.com/archive/maven"
        }
    }
}
apply plugin: "com.facebook.react.rootproject"

```


--- package.json
```
{
  "name": "MyApp",
  "version": "0.0.1",
  "private": true,
  "scripts": {
    "android": "react-native run-android",
    "ios": "react-native run-ios",
    "lint": "eslint .",
    "start": "react-native start",
    "test": "jest",
  },
  "dependencies": {
    "@mj-studio/react-native-naver-map": "^2.2.0",
    "@react-native-async-storage/async-storage": "^2.1.2",
    "@react-navigation/bottom-tabs": "^7.2.1",
    "@react-navigation/native": "^7.0.15",
    "@react-navigation/native-stack": "^7.2.1",
    "dayjs": "^1.11.13",
    "jotai": "^2.12.1",
    "react": "19.0.0",
    "react-native": "0.78.0",
    "react-native-gifted-charts": "^1.4.58",
    "react-native-navigation-bar-color": "^2.0.2",
    "react-native-safe-area-context": "^5.3.0",
    "react-native-screens": "^4.9.1",
    "react-native-svg": "^15.11.2",
    "styled-components": "^6.1.15"
  },
  "devDependencies": {
    "@babel/core": "^7.25.2",
    "@babel/preset-env": "^7.25.3",
    "@babel/runtime": "^7.25.0",
    "@react-native-community/cli": "15.0.1",
    "@react-native-community/cli-platform-android": "15.0.1",
    "@react-native-community/cli-platform-ios": "15.0.1",
    "@react-native/babel-preset": "0.78.0",
    "@react-native/eslint-config": "0.78.0",
    "@react-native/metro-config": "0.78.0",
    "@react-native/typescript-config": "0.78.0",
    "@types/jest": "^29.5.13",
    "@types/react": "^19.0.0",
    "@types/react-test-renderer": "^19.0.0",
    "@types/styled-components": "^5.1.34",
    "@types/styled-components-react-native": "^5.2.5",
    "babel-plugin-module-resolver": "^5.0.2",
    "eslint": "^8.19.0",
    "jest": "^29.6.3",
    "prettier": "2.8.8",
    "react-native-svg-transformer": "^1.5.0",
    "react-test-renderer": "19.0.0",
    "typescript": "5.0.4"
  },
  "engines": {
    "node": ">=18"
  }
}
```

