### PR TITLE
feat: iOS 카메라 이벤트 실시간 감지 기능 추가

### DIFF
--- a/ios/RNCNaverMapViewImpl.mm
+++ b/ios/RNCNaverMapViewImpl.mm
@@ -12,6 +12,9 @@
   BOOL _initialRegionSet;
   BOOL _initialCameraSet;
   BOOL _isFirstCameraAnimationRun;
+  
+  // iOS 카메라 변경 감지를 위한 추가 프로퍼티
+  BOOL _isUserInteracting;
 
   // Array to manually track RN subviews
   //
@@ -45,6 +48,7 @@
     dispatch_after(popTime, dispatch_get_main_queue(), ^(void) {
       if (!self.rncParent.emitter)
         return;
+      
       self.rncParent.emitter->onInitialized({});
     });
   }
@@ -61,6 +65,7 @@
   _initialRegionSet = NO;
   _initialCameraSet = NO;
   _isFirstCameraAnimationRun = NO;
+  _isUserInteracting = NO;
 }
 
 #pragma clang diagnostic push
@@ -211,6 +216,7 @@
   // noop
 }
 
+
 - (void)setLocationOverlay:(NSDictionary*)locationOverlay {
   auto o = self.mapView.locationOverlay;
   if (!o)
@@ -233,6 +239,7 @@
 - (void)mapView:(NMFMapView*)mapView cameraIsChangingByReason:(NSInteger)reason {
   if (!_rncParent.emitter)
     return;
+    
   NMFCameraPosition* pos = mapView.cameraPosition;
   NMGLatLngBounds* bounds = mapView.coveringBounds;
 
@@ -257,6 +264,10 @@
 - (void)mapViewCameraIdle:(NMFMapView*)mapView {
   if (!_rncParent.emitter)
     return;
+    
+  // 카메라 이동 완료 시 상호작용 상태 리셋
+  _isUserInteracting = NO;
+  
   NMFCameraPosition* pos = mapView.cameraPosition;
   NMGLatLngBounds* bounds = mapView.coveringBounds;
 
@@ -283,5 +294,23 @@
       .y = point.y,
   });
 }
+
+// iOS에서 실시간 카메라 변경 감지를 위한 새로운 델리게이트 메서드들
+- (void)mapView:(NMFMapView*)mapView cameraWillChangeByReason:(NSInteger)reason animated:(BOOL)animated {
+  // 카메라 변경이 시작될 때
+  _isUserInteracting = YES;
+  
+  // cameraIsChangingByReason과 동일한 이벤트 발생
+  [self mapView:mapView cameraIsChangingByReason:reason];
+}
+
+- (void)mapView:(NMFMapView*)mapView cameraDidChangeByReason:(NSInteger)reason animated:(BOOL)animated {
+  // 카메라 변경이 완료될 때도 이벤트 발생 (실시간 업데이트)
+  if (_isUserInteracting) {
+    [self mapView:mapView cameraIsChangingByReason:reason];
+  }
+}
+
+#pragma clang diagnostic pop
 
 @end


### PR DESCRIPTION
<!-- Thank you for contributing package 🤗 -->

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] Enhance (enhance performance, api, etc)

## What does this change?
###Description
- 문제 설명: iOS에서 onCameraChanged 실시간 호출 안됨
- 해결 방법: cameraWillChangeByReason, cameraDidChangeByReason 델리게이트 활용
- 테스트 결과: Android와 동일한 동작 확인
- Breaking Changes: 없음 (기존 API 유지)

###Test Cases
- 지도 드래그 시 실시간 이벤트 발생 확인
- 기존 기능들 정상 동작 확인

###Before (기존)
- iOS: 드래그 완료 후에만 onCameraChanged 호출
- Android: 드래그 중 실시간 onCameraChanged 호출
- 플랫폼 간 동작 불일치

###After (개선)
- iOS: 드래그 중 실시간 onCameraChanged 호출 ✅
- Android: 기존과 동일하게 정상 동작 ✅
- 플랫폼 간 일관된 동작

Fixes #<issue_number_goes_here> 🎯
https://github.com/mym0404/react-native-naver-map/issues/131
