### PR TITLE
fix: replace 0x0 bitmap creation with 1x1 transparent bitmap

### DIFF
--- a/android/src/main/java/com/mjstudio/reactnativenavermap/mapview/RNCNaverMapView.kt
+++ b/android/src/main/java/com/mjstudio/reactnativenavermap/mapview/RNCNaverMapView.kt
@@ -216,7 +216,7 @@ class RNCNaverMapView(
     locationOverlayImageRenderer.setImage(image) { overlayImage ->
       withMap {
         it.locationOverlay.icon = overlayImage ?: OverlayImage.fromBitmap(
-          Bitmap.createBitmap(0, 0, Bitmap.Config.ARGB_8888),
+          Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888),
         )
       }
     }
@@ -226,7 +226,7 @@ class RNCNaverMapView(
     locationOverlaySubImageRenderer.setImage(image) { overlayImage ->
       withMap {
         it.locationOverlay.icon = overlayImage ?: OverlayImage.fromBitmap(
-          Bitmap.createBitmap(0, 0, Bitmap.Config.ARGB_8888),
+          Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888),
         )
       }
     }

--- a/android/src/main/java/com/mjstudio/reactnativenavermap/overlay/ground/RNCNaverMapGround.kt
+++ b/android/src/main/java/com/mjstudio/reactnativenavermap/overlay/ground/RNCNaverMapGround.kt
@@ -56,6 +56,6 @@ class RNCNaverMapGround(
   override fun setOverlayImage(image: OverlayImage?) {
     isImageSet = true
     overlay.image =
-      image ?: OverlayImage.fromBitmap(Bitmap.createBitmap(0, 0, Bitmap.Config.ARGB_8888))
+      image ?: OverlayImage.fromBitmap(Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888))
   }
 }

--- a/android/src/main/java/com/mjstudio/reactnativenavermap/overlay/marker/RNCNaverMapMarker.kt
+++ b/android/src/main/java/com/mjstudio/reactnativenavermap/overlay/marker/RNCNaverMapMarker.kt
@@ -127,6 +127,6 @@ class RNCNaverMapMarker(
 
   override fun setOverlayImage(image: OverlayImage?) {
     overlay.icon =
-      image ?: OverlayImage.fromBitmap(createBitmap(0, 0))
+      image ?: OverlayImage.fromBitmap(createBitmap(1, 1))
   }
 }


### PR DESCRIPTION
## Summary
- Replace `Bitmap.createBitmap(0, 0)` calls with `createBitmap(1, 1)` to prevent `IllegalArgumentException`
- Fix crash that occurs when overlay image loading fails
- Maintain backward compatibility with minimal 1x1 transparent fallback

## Changes
- `RNCNaverMapView.kt`: Updated `setLocationOverlayImage()` and `setLocationOverlaySubImage()` methods  
- `RNCNaverMapMarker.kt`: Updated `setOverlayImage()` method
- `RNCNaverMapGround.kt`: Updated `setOverlayImage()` method

## Test plan
- [x] Build passes without errors
- [x] Fallback bitmaps now use valid 1x1 dimensions instead of invalid 0x0
- [ ] Manual test with network failure scenarios to verify no crashes occur

Fixes #143