### PR TITLE
feat: add locationTrackingMode to onOptionChanged event

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -275,7 +275,9 @@ const jejuRegion: Region = {
   logoAlign={'TopRight'}
   locale={'ja'}
   onInitialized={() => console.log('initialized!')}
-  onOptionChanged={() => console.log('Option Changed!')}
+  onOptionChanged={({ nativeEvent: { locationTrackingMode } }) => 
+    console.log('Option Changed!', locationTrackingMode)
+  }
   onCameraChanged={(args) => console.log(`Camera Changed: ${formatJson(args)}`)}
   onTapMap={(args) => console.log(`Map Tapped: ${formatJson(args)}`)}
 >

--- a/README.md
+++ b/README.md
@@ -271,7 +271,9 @@ const jejuRegion: Region = {
   logoAlign={'TopRight'}
   locale={'ja'}
   onInitialized={() => console.log('initialized!')}
-  onOptionChanged={() => console.log('Option Changed!')}
+  onOptionChanged={({ nativeEvent: { locationTrackingMode } }) => 
+    console.log('Option Changed!', locationTrackingMode)
+  }
   onCameraChanged={(args) => console.log(`Camera Changed: ${formatJson(args)}`)}
   onTapMap={(args) => console.log(`Map Tapped: ${formatJson(args)}`)}
 >

--- a/android/src/main/java/com/mjstudio/reactnativenavermap/event/NaverMapOptionChangeEvent.kt
+++ b/android/src/main/java/com/mjstudio/reactnativenavermap/event/NaverMapOptionChangeEvent.kt
@@ -7,6 +7,7 @@ import com.facebook.react.uimanager.events.Event
 class NaverMapOptionChangeEvent(
   surfaceId: Int,
   viewId: Int,
+  private val locationTrackingMode: String,
 ) : Event<NaverMapOptionChangeEvent>(surfaceId, viewId) {
   override fun getEventName(): String = EVENT_NAME
 
@@ -14,7 +15,10 @@ class NaverMapOptionChangeEvent(
 
   override fun getCoalescingKey(): Short = 0
 
-  override fun getEventData(): WritableMap = Arguments.createMap()
+  override fun getEventData(): WritableMap =
+    Arguments.createMap().apply {
+      putString("locationTrackingMode", locationTrackingMode)
+    }
 
   companion object {
     const val EVENT_NAME = "topOptionChanged"

--- a/android/src/main/java/com/mjstudio/reactnativenavermap/mapview/RNCNaverMapView.kt
+++ b/android/src/main/java/com/mjstudio/reactnativenavermap/mapview/RNCNaverMapView.kt
@@ -19,6 +19,7 @@ import com.mjstudio.reactnativenavermap.util.view.ViewAttacherGroup
 import com.naver.maps.map.CameraUpdate.REASON_CONTROL
 import com.naver.maps.map.CameraUpdate.REASON_GESTURE
 import com.naver.maps.map.CameraUpdate.REASON_LOCATION
+import com.naver.maps.map.LocationTrackingMode
 import com.naver.maps.map.MapView
 import com.naver.maps.map.NaverMap
 import com.naver.maps.map.NaverMapOptions
@@ -55,7 +56,15 @@ class RNCNaverMapView(
 
       it.addOnOptionChangeListener {
         reactContext.emitEvent(reactTag) { surfaceId, reactTag ->
-          NaverMapOptionChangeEvent(surfaceId, reactTag)
+          val modeString =
+            when (it.locationTrackingMode) {
+              LocationTrackingMode.None -> "None"
+              LocationTrackingMode.NoFollow -> "NoFollow"
+              LocationTrackingMode.Follow -> "Follow"
+              LocationTrackingMode.Face -> "Face"
+              else -> "None"
+            }
+          NaverMapOptionChangeEvent(surfaceId, reactTag, modeString)
         }
       }
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -342,7 +342,9 @@ export default function App() {
           isShowLocationButton={myLocation}
           // isExtentBoundedInKorea
           onInitialized={() => console.log('initialized!')}
-          // onOptionChanged={() => console.log('Option Changed!')}
+          onOptionChanged={({ nativeEvent: { locationTrackingMode } }) =>
+            console.log('Option Changed!', locationTrackingMode)
+          }
           onCameraChanged={({ region }) => {
             console.log(
               `Camera: ${formatJson({ latitude: region.latitude, longitude: region.longitude })}`

--- a/ios/RNCNaverMapViewImpl.mm
+++ b/ios/RNCNaverMapViewImpl.mm
@@ -228,7 +228,28 @@
 - (void)mapViewOptionChanged:(NMFMapView*)mapView {
   if (!_rncParent.emitter)
     return;
-  _rncParent.emitter->onOptionChanged({});
+
+  NSString* modeString;
+  switch (self.mapView.positionMode) {
+    case NMFMyPositionDisabled:
+      modeString = @"None";
+      break;
+    case NMFMyPositionNormal:
+      modeString = @"NoFollow";
+      break;
+    case NMFMyPositionDirection:
+      modeString = @"Follow";
+      break;
+    case NMFMyPositionCompass:
+      modeString = @"Face";
+      break;
+    default:
+      modeString = @"None";
+      break;
+  }
+
+  _rncParent.emitter->onOptionChanged(
+      {.locationTrackingMode = std::string([modeString UTF8String])});
 }
 
 - (void)mapView:(NMFMapView*)mapView cameraIsChangingByReason:(NSInteger)reason {

--- a/src/component/NaverMapView.tsx
+++ b/src/component/NaverMapView.tsx
@@ -432,7 +432,9 @@ export interface NaverMapViewProps extends ViewProps {
    *
    * @event
    */
-  onOptionChanged?: () => void;
+  onOptionChanged?: (event: {
+    nativeEvent: { locationTrackingMode: LocationTrackingMode | string };
+  }) => void;
   /**
    * 어떤 이유에 의해서건 카메라가 움직이면 카메라 변경 이벤트가 발생합니다.
    *

--- a/src/spec/RNCNaverMapViewNativeComponent.ts
+++ b/src/spec/RNCNaverMapViewNativeComponent.ts
@@ -151,7 +151,11 @@ interface Props extends ViewProps {
   locationOverlay?: Readonly<NativeLocationOverlayProp>;
 
   onInitialized?: DirectEventHandler<Readonly<{}>>;
-  onOptionChanged?: DirectEventHandler<Readonly<{}>>;
+  onOptionChanged?: DirectEventHandler<
+    Readonly<{
+      locationTrackingMode: string;
+    }>
+  >;
   onCameraChanged?: DirectEventHandler<
     Readonly<{
       latitude: Double;


### PR DESCRIPTION
<!-- Thank you for contributing package 🤗 -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhance (enhance performance, api, etc)
- [ ] Chore
- [X] This change requires a documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## What does this change?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

NaverMapView의 옵션(props)에는 단방향 상태 설정이 주를 이루지만, locationTrackingMode의 경우 사용자의 지도 사용 방식에 따라 지도 자체적으로 mode가 변경되는 경우가 있어 이 상태를 추적하고자 onOptionChanged 이벤트에 locationTrackingMode 파라미터를 추가했습니다.

While NaverMapView props are primarily for one-way state setting, locationTrackingMode can be automatically changed by the map itself based on user interaction patterns. To track this state, I've added a locationTrackingMode parameter to the onOptionChanged event.

