### PR TITLE
fix: remove deprecated setOverflow call for RN 0.81+ compatibility

### DIFF
--- a/android/src/main/java/com/mjstudio/reactnativenavermap/util/view/ViewAttacherGroup.kt
+++ b/android/src/main/java/com/mjstudio/reactnativenavermap/util/view/ViewAttacherGroup.kt
@@ -13,7 +13,6 @@ class ViewAttacherGroup(
     alpha = 0.0f
     removeClippedSubviews = false
     clipBounds = Rect(0, 0, 0, 0)
-    setOverflow("hidden") // Change to ViewProps.HIDDEN until RN 0.57 is base
   }
 
   // This should make it more performant, avoid trying to hard to overlap layers


### PR DESCRIPTION
## Summary
Remove deprecated `setOverflow("hidden")` call from ViewAttacherGroup initialization to fix Android build compatibility issues with React Native 0.81+.

## Changes
- Remove `setOverflow("hidden")` call from ViewAttacherGroup constructor
- This method was deprecated in newer React Native versions and causes build failures
- Visual behavior remains unchanged due to existing `clipBounds` setting

## Test Plan
- [x] Android build completes without deprecated method warnings
- [x] ViewAttacherGroup initialization works correctly
- [x] Clipping behavior remains consistent with previous implementation
- [x] No visual regressions in map overlay rendering

Closes #160