### PR TITLE
fix(ios): serialise access to the overlay image cache

### DIFF
--- a/ios/Util/Image/ImageUtil.h
+++ b/ios/Util/Image/ImageUtil.h
@@ -9,12 +9,33 @@
 #import "RNCNaverMapOverlayImageLoader.h"
 #import <Foundation/Foundation.h>
 #import <NMapsMap/NMapsMap.h>
+#import <mutex>
 #import <string>
 #import <unordered_map>
 
 typedef void (^RNCNaverMapOverlayImageHandler)(NMFOverlayImage* _Nullable);
 
 static std::unordered_map<std::string, NMFOverlayImage*> imageCache;
+
+// `imageCache` is reached from two threads: `getImage` reads it on the main
+// thread while `loadImageWith`'s image-loader completion writes it on the
+// loader's queue. Under ARC `imageCache[k] = v` releases the old value and
+// retains the new one, so markers sharing one asset URI over-release it when
+// their completions land together, and `unordered_map` rehashes on insert
+// while a reader is walking the buckets. Android already serialises this --
+// util/image/OverlayImageCache.kt is backed by a ConcurrentHashMap.
+static std::mutex imageCacheMutex;
+
+static NMFOverlayImage* _Nullable imageCacheGet(const std::string& key) {
+  std::lock_guard<std::mutex> guard(imageCacheMutex);
+  auto it = imageCache.find(key);
+  return it == imageCache.end() ? nil : it->second;
+}
+
+static void imageCachePut(const std::string& key, NMFOverlayImage* _Nonnull image) {
+  std::lock_guard<std::mutex> guard(imageCacheMutex);
+  imageCache[key] = image;
+}
 
 static RNCNaverMapImageCanceller _Nullable loadImageWith(
     std::string uri, std::string cacheKey, RNCNaverMapOverlayImageHandler _Nonnull callback) {
@@ -31,7 +52,7 @@ static RNCNaverMapImageCanceller _Nullable loadImageWith(
         NMFOverlayImage* overlayImage = [NMFOverlayImage overlayImageWithImage:image
                                                                reuseIdentifier:getNsStr(cacheKey)];
         callback(overlayImage);
-        imageCache[cacheKey] = overlayImage;
+        imageCachePut(cacheKey, overlayImage);
       });
 }
 
@@ -79,13 +100,12 @@ static RNCNaverMapImageCanceller _Nullable getImage(
   if (rnAssetUri.size() || httpUri.size()) {
     std::string uri = rnAssetUri.size() ? rnAssetUri : httpUri;
     std::string key = reuseIdentifier.size() ? reuseIdentifier : uri;
-    if (imageCache.find(key) != imageCache.end()) {
-      callback(imageCache[key]);
+    if (NMFOverlayImage* cached = imageCacheGet(key)) {
+      callback(cached);
       return ^{
       };
-    } else {
-      return loadImageWith(uri, key, callback);
     }
+    return loadImageWith(uri, key, callback);
   }
 
   if (assetName.size()) {


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What does this change?

Makes the iOS overlay image cache thread-safe. No existing issue — the detail is below.

## Problem

`ios/Util/Image/ImageUtil.h` reaches `imageCache` from two threads with no synchronisation:

- `getImage` reads it on the main thread — `imageCache.find(key)`, then `imageCache[key]`.
- `loadImageWith`'s `RCTImageLoader` completion writes it on the loader's queue — `imageCache[cacheKey] = overlayImage`.

Under ARC that assignment **releases the old value and retains the new one**. Markers that
share one asset URI share one cache key, so a screen with many markers issues N concurrent
image requests whose completions all assign the same key concurrently, releasing the old
value more than once. `std::unordered_map` also rehashes on insert, which can invalidate the
buckets the main thread is walking, and the `find`-then-`operator[]` pair is a TOCTOU on top.

The result is an over-released `NMFOverlayImage`, which surfaces two ways in production
crash reports:

```
Crashed: com.apple.main-thread
0  libobjc.A.dylib  objc_release + 16
2  NMapsMap         std::__1::default_delete<nmaps::map::OverlayImage::Impl>::operator()
3  NMapsMap         nmaps::map::OverlayImage::~OverlayImage()
5  NMapsMap         nmaps::map::MarkerProps::~MarkerProps()
7  NMapsMap         nmaps::map::RenderMarker::~RenderMarker()
19 NMapsMap         nmaps::map::Map::~Map()
```

and, once the freed allocation has been reused by an unrelated object:

```
Fatal Exception: NSInvalidArgumentException
-[_UIImageCGImageContent reuseIdentifier]: unrecognized selector sent to instance 0x…
6  app  RNCNaverMapMarker.mm:104  __30-[RNCNaverMapMarker setImage:]_block_invoke_2 + 104
7  libdispatch.dylib  _dispatch_call_block_and_release
```

That second one is `self.inner.iconImage = image;` handing the SDK a pointer that is no
longer an `NMFOverlayImage`, so `-reuseIdentifier` lands on whatever now occupies the
address. In our app this concentrated on cold start — 92% of those events fired within the
first five seconds of a session, when a screenful of markers mounts at once.

## Fix

Serialise cache access behind one mutex, and collapse the `find`-then-`operator[]` pair into
a single guarded lookup. The lookup returns into a `__strong` local, so ARC retains the value
while the lock is held and a concurrent overwrite cannot free it before the callback runs.

This is the guarantee the Android side already has —
`android/src/main/java/com/mjstudio/reactnativenavermap/util/image/OverlayImageCache.kt`
backs its store with a `ConcurrentHashMap`. The change just brings iOS in line.

`static` at header scope is left as-is: each translation unit keeps its own cache and its own
mutex, which stays correct because a unit only touches its own copy. Changing that is a
behaviour change rather than a crash fix, so it is deliberately out of scope here.

## Notes

- No public API change, and no behaviour change on either the hit or the miss path.
- The crash data above is production Crashlytics from a shipping app on 2.7.1 — 59 of 67 open crash events in a 7-day window, across 35 users, with crash-free users at 96.47%.
- I have not reproduced the race under Thread Sanitizer; it is inferred from the two stack shapes plus the unsynchronised access, which is why the patch is written as a strict serialisation rather than a targeted change. The patched build compiles and runs the affected screens (many markers sharing one asset URI, plus repeated map teardown) without regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
